### PR TITLE
Make Makefile more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,18 @@ CFLAGS += `pkg-config --cflags xtst x11`
 LDFLAGS += `pkg-config --libs xtst x11`
 LDFLAGS += -pthread
 
+all: $(TARGET)
+
 $(TARGET): xcape.c
 	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
 
 install:
-	$(INSTALL) -Dm 755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
-	$(INSTALL) -Dm 644 xcape.1 $(DESTDIR)$(PREFIX)$(MANDIR)/xcape.1
+	$(INSTALL) -d -m 0755 $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) -d -m 0755 $(DESTDIR)$(PREFIX)$(MANDIR)
+	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
+	$(INSTALL) -m 0644 xcape.1 $(DESTDIR)$(PREFIX)$(MANDIR)/xcape.1
 
 clean:
 	rm $(TARGET)
 
-.PHONY: clean
+.PHONY: all clean install


### PR DESCRIPTION
- Use -d instead of -D
  -D seems to be a GNU extension.
- Add all target
  Just for convention. Not particularly attached to this.
- Mark install target as phony