### PR TITLE
Add '-f' flag (implied by '-d' flag).

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,15 @@ Then run:
 
 Usage
 -----
-    $ xcape [-d] [-t <timeout ms>] [-e <map-expression>]
+    $ xcape [-d] [-f] [-t <timeout ms>] [-e <map-expression>]
 
 ### `-d`
 
-Debug mode. Does not fork into the background.
+Debug mode. Does not fork into the background. Prints debug information.
+
+### `-f`
+
+Foreground mode. Does not fork into the background.
 
 ### `-t <timeout ms>`
 

--- a/xcape.1
+++ b/xcape.1
@@ -1,4 +1,4 @@
-.TH XCAPE 1 2014-02-13 "John Hill" "xcape Manual"
+.TH XCAPE 1 2017-07-03 "John Hill" "xcape Manual"
 
 .SH NAME
 xcape \- use a modifier key as another key
@@ -6,6 +6,7 @@ xcape \- use a modifier key as another key
 .SH SYNOPSIS
 .B xcape
 [\fB-d\fR]
+[\fB-f\fR]
 [\fB-t\fR \fItimeout\fR]
 [\fB-e\fR \fImap-expression\fR]
 
@@ -17,7 +18,10 @@ key in place of \fIControl_L\fR (Left Control).
 .SH OPTIONS
 .TP
 .BR \-d
-Debug mode.  Will run as a foreground process.
+Debug mode.  Will run as a foreground process and print debug information.
+.TP
+.BR \-f
+Foreground mode.  Will run as a foreground process.
 .TP
 .BR \-t " " \fItimeout\fR
 Give a \fItimeout\fR in milliseconds.  If you hold a key longer than

--- a/xcape.c
+++ b/xcape.c
@@ -62,6 +62,7 @@ typedef struct _XCape_t
     XRecordContext record_ctx;
     pthread_t sigwait_thread;
     sigset_t sigset;
+    Bool foreground;
     Bool debug;
     KeyMap_t *map;
     Key_t *generated;
@@ -100,6 +101,7 @@ int main (int argc, char **argv)
     XRecordRange *rec_range = XRecordAllocRange();
     XRecordClientSpec client_spec = XRecordAllClients;
 
+    self->foreground = False;
     self->debug = False;
     self->timeout.tv_sec = 0;
     self->timeout.tv_usec = 500000;
@@ -108,12 +110,15 @@ int main (int argc, char **argv)
     rec_range->device_events.first = KeyPress;
     rec_range->device_events.last = ButtonRelease;
 
-    while ((ch = getopt (argc, argv, "de:t:")) != -1)
+    while ((ch = getopt (argc, argv, "dfe:t:")) != -1)
     {
         switch (ch)
         {
         case 'd':
             self->debug = True;
+            /* imply -f (no break) */
+        case 'f':
+            self->foreground = True;
             break;
         case 'e':
             mapping = optarg;
@@ -187,7 +192,7 @@ int main (int argc, char **argv)
         exit (EXIT_FAILURE);
     }
 
-    if (self->debug != True)
+    if (self->foreground != True)
         daemon (0, 0);
 
     sigemptyset (&self->sigset);
@@ -565,6 +570,6 @@ void delete_keys (Key_t *keys)
 
 void print_usage (const char *program_name)
 {
-    fprintf (stdout, "Usage: %s [-d] [-t timeout_ms] [-e <mapping>]\n", program_name);
-    fprintf (stdout, "Runs as a daemon unless -d flag is set\n");
+    fprintf (stdout, "Usage: %s [-d] [-f] [-t timeout_ms] [-e <mapping>]\n", program_name);
+    fprintf (stdout, "Runs as a daemon unless -d or -f flag is set\n");
 }


### PR DESCRIPTION
Fixes #64.

Useful to let systemd spawn and monitor the daemon (requires foreground process or PID file). The `-d` flag combined with `> /dev/null` would waste resources by generating debug information on each event.