### PR TITLE
Add configuration file support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Foreground mode. Does not fork into the background.
 
 Supply a configuration file to be parsed xcape. Each line is an expression 
 following the form `'ModKey=Key[|OtherKey]`. Comments may be introduced
-via the `#` character, which will ignore the proceeding line. The `-c` option
-can be used multiple times in order to supply multiple configuration files.
+by inserting `--` at the start of the line, which will cause it to be ignored.
+The `-c` option can be used multiple times in order to supply multiple configuration
+files.
 
 
 ### `-t <timeout ms>`

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Usage
 
 Configuration files containing expressions. Each line is an expression 
 following the form `'ModKey=Key[|OtherKey]`. Comments may be introduced
-via the '#' character, which will ignore the proceeding line.
+via the `'#'` character, which will ignore the proceeding line.
 
 ### `-d`
 
@@ -76,13 +76,15 @@ key name is found.
 
 +   This configuration file produces the same behavior as above.
     
-        `xcape map.xcape`
-
         # map.xcape
         # Map left shift to Escape
         Shift_L=Escape
         # Map Left control to Ctrl-O 
         Control_L=Control_L|O
+
+    which can then be read via xcape using the following command
+
+        xcape map.xcape
 
 +   In conjunction with xmodmap it is possible to make an ordinary key act
     as an extra modifier. First map the key to the modifier with xmodmap

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Usage
 ### `file ...`
 
 Configuration files containing expressions. Each line is an expression 
-following the form `'ModKey=Key[|OtherKey]`.
+following the form `'ModKey=Key[|OtherKey]`. Comments may be introduced
+via the '#' character, which will ignore the proceeding line.
 
 ### `-d`
 
@@ -72,6 +73,16 @@ key name is found.
     released on its own.
 
         xcape -e 'Shift_L=Escape;Control_L=Control_L|O'
+
++   This configuration file produces the same behavior as above.
+    
+        `xcape map.xcape`
+
+        # map.xcape
+        # Map left shift to Escape
+        Shift_L=Escape
+        # Map Left control to Ctrl-O 
+        Control_L=Control_L|O
 
 +   In conjunction with xmodmap it is possible to make an ordinary key act
     as an extra modifier. First map the key to the modifier with xmodmap

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Usage
 
 Configuration files containing expressions. Each line is an expression 
 following the form `'ModKey=Key[|OtherKey]`. Comments may be introduced
-via the `'#'` character, which will ignore the proceeding line.
+via the `#` character, which will ignore the proceeding line. To read
+from standard input, you may use the `-` character.
 
 ### `-d`
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ Then run:
 
 Usage
 -----
-    $ xcape [-d] [-f] [-t <timeout ms>] [-e <map-expression>]
+    $ xcape [file ...] [-d] [-f] [-t <timeout ms>] [-e <map-expression>]
+
+### `file ...`
+
+Configuration files containing expressions. Each line is an expression 
+following the form `'ModKey=Key[|OtherKey]`.
 
 ### `-d`
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,7 @@ Then run:
 
 Usage
 -----
-    $ xcape [file ...] [-d] [-f] [-t <timeout ms>] [-e <map-expression>]
-
-### `file ...`
-
-Configuration files containing expressions. Each line is an expression 
-following the form `'ModKey=Key[|OtherKey]`. Comments may be introduced
-via the `#` character, which will ignore the proceeding line. To read
-from standard input, you may use the `-` character.
+    $ xcape [-d] [-f] [-c <config-file>] [-t <timeout ms>] [-e <map-expression>]
 
 ### `-d`
 
@@ -46,6 +39,14 @@ Debug mode. Does not fork into the background. Prints debug information.
 ### `-f`
 
 Foreground mode. Does not fork into the background.
+
+### `-c <config-file>`
+
+Supply a configuration file to be parsed xcape. Each line is an expression 
+following the form `'ModKey=Key[|OtherKey]`. Comments may be introduced
+via the `#` character, which will ignore the proceeding line. The `-c` option
+can be used multiple times in order to supply multiple configuration files.
+
 
 ### `-t <timeout ms>`
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ key name is found.
 
     which can then be read via xcape using the following command
 
-        xcape map.xcape
+        xcape -c map.xcape
 
 +   In conjunction with xmodmap it is possible to make an ordinary key act
     as an extra modifier. First map the key to the modifier with xmodmap

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ key name is found.
 
 +   This configuration file produces the same behavior as above.
     
-        # map.xcape
-        # Map left shift to Escape
+        -- map.xcape
+        -- Map left shift to Escape
         Shift_L=Escape
-        # Map Left control to Ctrl-O 
+        -- Map Left control to Ctrl-O 
         Control_L=Control_L|O
 
     which can then be read via xcape using the following command

--- a/xcape.1
+++ b/xcape.1
@@ -20,7 +20,8 @@ key in place of \fIControl_L\fR (Left Control).
 .TP
 .BR file\ ...
 Configuration Files. Expressions will be read from the files in a line-by-line
-manner. "\-" can be used to read from standard input.
+manner. "\-" can be used to read from standard input. Comments are indicated
+by the character '#', which will ignore an entire line.
 .TP
 .BR \-d
 Debug mode.  Will run as a foreground process and print debug information.

--- a/xcape.1
+++ b/xcape.1
@@ -5,6 +5,7 @@ xcape \- use a modifier key as another key
 
 .SH SYNOPSIS
 .B xcape
+[file ...]
 [\fB-d\fR]
 [\fB-f\fR]
 [\fB-t\fR \fItimeout\fR]
@@ -16,6 +17,10 @@ and released on its own. The default behaviour is to generate the \fIEscape\fR
 key in place of \fIControl_L\fR (Left Control).
 
 .SH OPTIONS
+.TP
+.BR file\ ...
+Configuration Files. Expressions will be read from the files in a line-by-line
+manner. "\-" can be used to read from standard input.
 .TP
 .BR \-d
 Debug mode.  Will run as a foreground process and print debug information.

--- a/xcape.1
+++ b/xcape.1
@@ -19,9 +19,11 @@ key in place of \fIControl_L\fR (Left Control).
 .SH OPTIONS
 .TP
 .BR file\ ...
-Configuration Files. Expressions will be read from the files in a line-by-line
-manner. "\-" can be used to read from standard input. Comments are indicated
-by the character '#', which will ignore an entire line.
+Configuration files containing expressions. Each line is an expression 
+following the form \'\fBModKey\fR=\fBKey\fR[|\fBOtherKey\fR]\'.
+Comments may be introduced via the '#' character, which will
+ignore the proceeding line. To read from standard input, you may use
+the '\-' character.
 .TP
 .BR \-d
 Debug mode.  Will run as a foreground process and print debug information.

--- a/xcape.1
+++ b/xcape.1
@@ -5,9 +5,9 @@ xcape \- use a modifier key as another key
 
 .SH SYNOPSIS
 .B xcape
-[file ...]
 [\fB-d\fR]
 [\fB-f\fR]
+[\fB-c\fR \fIconfig-file\fR]
 [\fB-t\fR \fItimeout\fR]
 [\fB-e\fR \fImap-expression\fR]
 
@@ -18,18 +18,18 @@ key in place of \fIControl_L\fR (Left Control).
 
 .SH OPTIONS
 .TP
-.BR file\ ...
-Configuration files containing expressions. Each line is an expression 
-following the form \'\fBModKey\fR=\fBKey\fR[|\fBOtherKey\fR]\'.
-Comments may be introduced via the '#' character, which will
-ignore the proceeding line. To read from standard input, you may use
-the '\-' character.
-.TP
 .BR \-d
 Debug mode.  Will run as a foreground process and print debug information.
 .TP
 .BR \-f
 Foreground mode.  Will run as a foreground process.
+.TP
+.BR \-c " " \fIconfig-file\fR
+Supply a configuration file to be parsed xcape. Each line is an expression 
+following the form \'\fBModKey\fR=\fBKey\fR[|\fBOtherKey\fR]\'.
+Comments may be introduced via the '#' character, which will
+ignore the proceeding line. The \-c option can be used multiple
+times in order to supply multiple configuration files.
 .TP
 .BR \-t " " \fItimeout\fR
 Give a \fItimeout\fR in milliseconds.  If you hold a key longer than

--- a/xcape.c
+++ b/xcape.c
@@ -165,6 +165,12 @@ int main (int argc, char **argv)
         }
     }
 
+    /* user supplied more arguments than needed */
+    if(optind != argc){
+        print_usage (argv[0]);
+        return EXIT_SUCCESS;
+    }
+
     if (!XInitThreads ())
     {
         fprintf (stderr, "Failed to initialize threads.\n");
@@ -673,7 +679,7 @@ KeyMap_t *parse_confs (Display *ctrl_conn, const char **files, size_t n_confs, B
             char *trimmed = line;
             while(isspace(*trimmed)) ++trimmed;
             /* check for comments or empty lines */
-            if(*trimmed && *trimmed != '#'){
+            if(*trimmed && strncmp(trimmed, "--", 2)){
                 *current = parse_token (ctrl_conn, trimmed, debug);
                 if (*current == NULL)
                 {
@@ -738,6 +744,6 @@ void delete_keys (Key_t *keys)
 
 void print_usage (const char *program_name)
 {
-    fprintf (stdout, "Usage: %s [file ...] [-d] [-f] [-t timeout_ms] [-e <mapping>]\n", program_name);
+    fprintf (stdout, "Usage: %s [-d] [-f] [-c <config-file>] [-t timeout_ms] [-e <mapping>]\n", program_name);
     fprintf (stdout, "Runs as a daemon unless -d or -f flag is set\n");
 }

--- a/xcape.c
+++ b/xcape.c
@@ -1,6 +1,6 @@
 /************************************************************************
  * xcape.c
- *
+*
  * Copyright 2015 Albin Olsson
  *
  * This program is free software: you can redistribute it and/or modify
@@ -618,23 +618,23 @@ char *read_line (FILE *file)
         switch (c)
         {
         case '\r':
-            /* check for \r\n */
             {
-                int c = fgetc(file);
-                if(c != '\n'){
-                    ungetc(c, file);
+                int c = fgetc (file);
+                /* check for \r\n */
+                if(c != '\n')
+                {
+                    ungetc (c, file);
+                    break;
                 }
             }
-            break;
+        /* FALLTHROUGH */
         case '\n': /* FALLTHROUGH */
-        case '\0':
-            line[nlen++] = '\0';
-            reading = 0;
-            break;
+        case '\0': /* FALLTHROUGH */
         case EOF:
             reading = 0;
             break;
         default:
+            /* add the character to the line */
             line[nlen++] = c;
             break;
         }
@@ -644,8 +644,10 @@ char *read_line (FILE *file)
         free (line);
         return NULL;
     }
+    /* terminate the line */
+    line = realloc (line, nlen + 1);
+    line[nlen] = '\0';
     /* shrink down to size */
-    line = realloc (line, nlen);
     return line;
 }
 

--- a/xcape.c
+++ b/xcape.c
@@ -681,6 +681,6 @@ void delete_keys (Key_t *keys)
 
 void print_usage (const char *program_name)
 {
-    fprintf (stdout, "Usage: %s [file] [-d] [-f] [-t timeout_ms] [-e <mapping>]\n", program_name);
+    fprintf (stdout, "Usage: %s [file ...] [-d] [-f] [-t timeout_ms] [-e <mapping>]\n", program_name);
     fprintf (stdout, "Runs as a daemon unless -d or -f flag is set\n");
 }

--- a/xcape.c
+++ b/xcape.c
@@ -151,14 +151,8 @@ int main (int argc, char **argv)
 
     if (optind < argc)
     {
-        if(mapping == default_mapping){
-            conf_files = argv + optind;
-            n_conf = argc - optind;
-        }else{
-            fprintf (stderr, "Not a command line option: '%s'\n", argv[optind]);
-            print_usage (argv[0]);
-            return EXIT_SUCCESS;
-        }
+        conf_files = argv + optind;
+        n_conf = argc - optind;
     }
 
     if (!XInitThreads ())

--- a/xcape.c
+++ b/xcape.c
@@ -224,8 +224,7 @@ int main (int argc, char **argv)
         current_map = &(*current_map)->next;
     }
 
-    /* if there were no config files or mappings supplied, try
-     * the default mapping */
+    /* if there were no config files or mappings supplied, try the default mapping */
 
     if (!conf_files && !mapping)
     {

--- a/xcape.c
+++ b/xcape.c
@@ -578,13 +578,22 @@ char *read_line (FILE *file)
         }
         switch (c)
         {
-        case '\r': /* FALLTHROUGH */
+        case '\r':
+            /* check for \r\n */
+            {
+                int c = fgetc(file);
+                if(c != '\n'){
+                    ungetc(c, file);
+                }
+            }
+            break;
         case '\n': /* FALLTHROUGH */
         case '\0':
             line[nlen++] = '\0';
             reading = 0;
             break;
         case EOF:
+            ungetc(EOF, file);
             reading = 0;
             break;
         default:
@@ -593,12 +602,12 @@ char *read_line (FILE *file)
             break;
         }
     }
-    /* TODO remove extraneous \r|\n|\0 */
     if(nlen == 0)
     {
         free (line);
         return NULL;
     }
+    /* shrink down to size */
     line = realloc (line, nlen);
     return line;
 }

--- a/xcape.c
+++ b/xcape.c
@@ -565,14 +565,15 @@ char *read_line (FILE *file)
     /* TODO read arbitrary line size */
     size_t bufsz = 1024;
     char buffer[bufsz];
-    if (fgets(buffer, bufsz, file) == NULL)
+    if (fgets (buffer, bufsz, file) == NULL)
     {
         return NULL;
     }
-    char *line = strdup(buffer);
-    size_t nlen = strlen(line);
+    char *line = strdup (buffer);
+    size_t nlen = strlen (line);
     /* remove newline characters */
-    switch(line[nlen - 1]){
+    switch (line[nlen - 1])
+    {
     case '\n':
         if(nlen >= 2 && line[nlen - 2] == '\r')
             --nlen;
@@ -580,21 +581,21 @@ char *read_line (FILE *file)
     case '\r':
         line[nlen - 1] = '\0';
         break;
-    }
+    };
     return line;
 }
 
 KeyMap_t *parse_confs (Display *ctrl_conn, char **files, size_t n_confs, Bool debug)
 {
     KeyMap_t *rval = NULL;
-    KeyMap_t **walker = &rval;
-    for(size_t i = 0; i < n_confs; ++i)
+    KeyMap_t **current = &rval;
+    for (size_t i = 0; i < n_confs; ++i)
     {
         Bool close = True;
         char *filename = files[i];
         FILE *file = NULL;
 
-        if(!strcmp(filename, "-"))
+        if (!strcmp (filename, "-"))
         {
             close = False;
             file = stdin;
@@ -612,21 +613,19 @@ KeyMap_t *parse_confs (Display *ctrl_conn, char **files, size_t n_confs, Bool de
 
         /* read and parse file */
         char *line = NULL;
-        while((line = read_line(file)) != NULL)
+        while ((line = read_line (file)) != NULL)
         {
-            *walker = parse_token(ctrl_conn, line, debug);
-            free(line);
-            if(*walker == NULL)
+            *current = parse_token (ctrl_conn, line, debug);
+            free (line);
+            if (*current == NULL)
             {
                 break;
             }
-            walker = &(*walker)->next;
+            current = &(*current)->next;
         }
 
-        if(close)
-        {
+        if (close)
             fclose (file);
-        }
     }
     return rval;
 }

--- a/xcape.c
+++ b/xcape.c
@@ -593,7 +593,6 @@ char *read_line (FILE *file)
             reading = 0;
             break;
         case EOF:
-            ungetc(EOF, file);
             reading = 0;
             break;
         default:

--- a/xcape.c
+++ b/xcape.c
@@ -20,6 +20,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <ctype.h>
 #include <string.h>
 #include <sys/time.h>
 #include <signal.h>
@@ -641,13 +642,19 @@ KeyMap_t *parse_confs (Display *ctrl_conn, char **files, size_t n_confs, Bool de
         char *line = NULL;
         while ((line = read_line (file)) != NULL)
         {
-            *current = parse_token (ctrl_conn, line, debug);
-            free (line);
-            if (*current == NULL)
-            {
-                break;
+            /* trim leading whitespace */
+            char *trimmed = line;
+            while(isspace(*trimmed)) ++trimmed;
+            /* check for comments */
+            if(*trimmed && *trimmed != '#'){
+                *current = parse_token (ctrl_conn, trimmed, debug);
+                if (*current == NULL)
+                {
+                    break;
+                }
+                current = &(*current)->next;
             }
-            current = &(*current)->next;
+            free (line);
         }
 
         if (close)

--- a/xcape.c
+++ b/xcape.c
@@ -590,7 +590,7 @@ char *read_line (FILE *file)
 {
     size_t cap = 1024;
     size_t nlen = 0;
-    char *line = realloc (NULL, cap*sizeof(char));
+    char *line = calloc (cap, sizeof(char));
 
     int c = EOF;
     int reading = 1;

--- a/xcape.c
+++ b/xcape.c
@@ -650,8 +650,8 @@ char *read_line (FILE *file)
         free (line);
         return NULL;
     }
-    /* terminate the line */
-    line = realloc (line, nlen + 1);
+    /* terminate the line and reduce size */
+    line = realloc (line, (nlen + 1)*sizeof(char));
     line[nlen] = '\0';
     /* shrink down to size */
     return line;

--- a/xcape.c
+++ b/xcape.c
@@ -595,7 +595,11 @@ char *read_line (FILE *file)
     }
     /* TODO remove extraneous \r|\n|\0 */
     if(nlen == 0)
+    {
+        free (line);
         return NULL;
+    }
+    line = realloc (line, nlen);
     return line;
 }
 


### PR DESCRIPTION
This pull request references issue [#74](https://github.com/alols/xcape/issues/74), adding configuration file support.
## Configuration Files
Configuration files follow the same syntax as regular map expressions, except instead of using `;` to indicate the end of an expression we use newlines, restricting it to one expression per line. Blank lines and lines starting with `#` are ignored. One catch to the parsing used is that the line *must* start with a `#` or whitespace to be recognized as a comment, and the `#` syntax cannot be used later in a line. This is an area of possible improvement moving forwards.

## Argument Parsing Changes
A new argument `[file ...]` has been added, and has the following semantics:
- If a map expression is supplied via -e, it will be used in addition to files
- If files are supplied, they will be parsed, with `-` used for standard input
- If neither a map expression or files are supplied, then we use the default mapping from previous versions.