### PR TITLE
Add Keycode shift level and group support.

### DIFF
--- a/xcape.1
+++ b/xcape.1
@@ -44,10 +44,12 @@ generate "\fI{\fR" the expression
 (assuming that you have a key with \'{\' above \'[\').
 .PP
 You can also specify \fBModKey\fR in decimal (prefix \fI#\fR), octal
-(\fI#0\fR), or hexadecimal (\fI#0x\fR). It will be interpreted as a keycode unless no coresponding key name is found.
+(\fI#0\fR), or hexadecimal (\fI#0x\fR). It will be interpreted as a keycode if no coresponding key name is found.
 
-When specifying the Modkey using numbers, is is possible to also set the kslag (Keycode Shift Level And Group) by following the number with a \f\-\fR and the keysys column. It will be interpreted as a keycode unless no corresponding key name is
+When specifying the Modkey using numbers, is is possible to also set the kslag (Keycode Shift Level And Group) by following the number with a \f\\-\fR and the keysys column number. It will be interpreted as a keycode if no corresponding key name is
 found.
+
+If a keysys column number is not defined, it will always return as 0.
 
 .SH EXAMPLES
 .PP

--- a/xcape.1
+++ b/xcape.1
@@ -44,16 +44,17 @@ generate "\fI{\fR" the expression
 (assuming that you have a key with \'{\' above \'[\').
 .PP
 You can also specify \fBModKey\fR in decimal (prefix \fI#\fR), octal
-(\fI#0\fR), or hexadecimal (\fI#0x\fR). It will be interpreted as a keycode
-unless no corresponding key name is
+(\fI#0\fR), or hexadecimal (\fI#0x\fR). It will be interpreted as a keycode unless no coresponding key name is found.
+
+When specifying the Modkey using numbers, is is possible to also set the kslag (Keycode Shift Level And Group) by following the number with a \f\-\fR and the keysys column. It will be interpreted as a keycode unless no corresponding key name is
 found.
 
 .SH EXAMPLES
 .PP
 Make Left Shift generate Escape when pressed and released on it's own, and Left
-Control generate Ctrl\-O combination when pressed and released on it's own:
+Control plus shift generate Ctrl\-O combination when pressed and released on it's own:
 .RS
-\fBxcape\fR \fB-e\fR '\fIShift_L\fR=\fIEscape\fR;\fIControl_L\fR=\fIControl_L\fR|\fIO\fR'
+\fBxcape\fR \fB-e\fR '\fIShift_L\fR=\fIEscape\fR;\fIControl_L-1\fR=\fIControl_L\fR|\fIO\fR'
 .RE
 .PP
 In conjugation with xmodmap it is possible to make an ordinary key act as an


### PR DESCRIPTION
Added the ability to set the keysys column(s) effected when setting a key in xcape. This allows the other 31 other key column values to still be used natively in xorg, with xcape only activating over the specified instance(s) instead of every instance of the key press.