### PR TITLE
docs: mention default timeout in xcape.1 manpage

### DIFF
--- a/xcape.1
+++ b/xcape.1
@@ -25,7 +25,7 @@ Foreground mode.  Will run as a foreground process.
 .TP
 .BR \-t " " \fItimeout\fR
 Give a \fItimeout\fR in milliseconds.  If you hold a key longer than
-\fItimeout\fR a key event will not be generated.
+\fItimeout\fR a key event will not be generated. The default is 500 ms.
 .TP
 .BR \-e " " \fImap-expression\fR
 Use \fImap-expression\fR as the expression(s).


### PR DESCRIPTION
I was looking for the default but couldn't find it anywhere until I found this repo. This small addition will let users know that the default timeout value is 500 ms.